### PR TITLE
Develop - added "alteredQuery" field to LuisResult, and ability to toggle spell checker to LuisClient.

### DIFF
--- a/ClientLibrary/Structures/LuisResult.cs
+++ b/ClientLibrary/Structures/LuisResult.cs
@@ -50,7 +50,13 @@ namespace Microsoft.Cognitive.LUIS
         /// <summary>
         /// Original text sent to the LUIS service for parsing.
         /// </summary>
-        public string OriginalQuery { get; set; }
+        public string OriginalQuery { get; set; }        
+
+        /// <summary>
+        /// Original text that has been spell-corrected with Luis-Bing integration.
+        /// </summary>
+        /// <remarks>Only has a value if the original query was changed.</remarks>
+        public string AlteredQuery { get; set; }
 
         /// <summary>
         /// The best matching intent in this result set.
@@ -113,6 +119,7 @@ namespace Microsoft.Cognitive.LUIS
             if (result == null) throw new ArgumentNullException(nameof(result));
 
             OriginalQuery = (string)result["query"] ?? string.Empty;
+            AlteredQuery = (string)result["alteredQuery"] ?? string.Empty;
             var intents = (JArray)result["intents"] ?? new JArray();
             TopScoringIntent = new Intent();
             TopScoringIntent.Load((JObject)result["topScoringIntent"]);


### PR DESCRIPTION
When Luis responses are spell-corrected with Bing, the Luis response contains an "alteredQuery" field. I have added the "alteredQuery" field to the LuisResult class so that it can be used by consumers of the library.