### PR TITLE
Fix for bug #61. Null reference error if entity.type is null.

### DIFF
--- a/ClientLibrary/Structures/LuisResult.cs
+++ b/ClientLibrary/Structures/LuisResult.cs
@@ -187,14 +187,19 @@ namespace Microsoft.Cognitive.LUIS
             return a;
         }
 
-        private IDictionary<string, IList<Entity>> ParseEntityArrayToDictionary (JArray array)
+        /// <summary>
+        /// Parses a json array of entities into an entity dictionary.
+        /// </summary>
+        /// <param name="array"></param>
+        /// <returns>The object containing the dictionary of entities</returns>
+        private IDictionary<string, IList<Entity>> ParseEntityArrayToDictionary(JArray array)
         {
             var dict = new Dictionary<string, IList<Entity>>();
 
             foreach (var item in array)
             {
                 var e = new Entity();
-                e.Load((JObject) item);
+                e.Load((JObject)item);
 
                 if (ShouldIgnoreEntity(e))
                 {


### PR DESCRIPTION
LUIS now returns some entities with type equal to null. This fix ensures those entities are ignored. Caused a null reference exception.

![luis](https://user-images.githubusercontent.com/915354/31608616-27d03106-b271-11e7-8b02-58e7ad19af11.png)



